### PR TITLE
Fix broken link to GSoC 2026 ideas list

### DIFF
--- a/materials/contributor_guidance.md
+++ b/materials/contributor_guidance.md
@@ -10,7 +10,7 @@ These rules are intended to make the program rewarding and problem-free for ever
 Please note that Google Summer of Code requires a time commitment of 20-40 hours per week, depending on the size of the tasks you choose. If you're considering taking on an additional part-time job, have extensive exams, or plan an extended vacation during the program, you need to carefully evaluate whether you can manage all these commitments without risking burnout. To help us better assess your availability, <ins>please make sure to explicitly list any other obligations in your application.</ins>
 
 - **Get in touch with us and our community**
- In particular, visit our [Zulip workspace](https://p4lang.zulipchat.com/), [P4 forum](https://forum.p4.org), [P4 Linkdin](https://www.linkedin.com/company/p4-language-consortium/) and/or email the mentors listed on the [ideas list](ideas_list.md) for each project that sounds appealing to you.
+ In particular, visit our [Zulip workspace](https://p4lang.zulipchat.com/), [P4 forum](https://forum.p4.org), [P4 Linkdin](https://www.linkedin.com/company/p4-language-consortium/) and/or email the mentors listed on the [ideas list](/2026/ideas_list.md) for each project that sounds appealing to you.
 
 - **Respect Mentors, Deliver on Time**
 The P4 Language Consortium values your enthusiasm and willingness to contribute. However, contacting mentors on multiple platforms, sending repeated messages, or asking for shortcuts may be viewed as unprofessional. Likewise, requesting last-minute reviews or urgent feedback when you are close to a deadline can be interpreted as a lack of reliability. Please remember that P4 mentors and admins volunteer their time to support a meaningful and successful GSoC experience.


### PR DESCRIPTION
Updated the link to the ideas list in the contributor guidance.
@Dscano, I had look after tst meeting, and saw this bug.

I see that the contributor_guide.md has become a common material, athough, I attached it to 2026, coz that felt most relevant though.
