### PR TITLE
Update publish-wiki

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: read
-
 jobs:
   publish-wiki:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'publishwiki')


### PR DESCRIPTION
@fruffy I reworked and tested `publish-wiki`. To get it working, I had to add a secret token in my gsoc fork, but I’m not sure what the p4lang policy is for using tokens/secrets in GitHub Actions, and I don’t think I’m authorized to set this up.