### PR TITLE
Put up a note that the BMv2 project is under discussion

### DIFF
--- a/2026/ideas_list.md
+++ b/2026/ideas_list.md
@@ -64,7 +64,7 @@ It means we expect you to have made relevant contributions in order to demonstra
 ### Index
 
 - Category: core P4 tooling
-  - [Project 1: Modernizing the P4 Software Switch BMv2](#project-1)
+  - [Under Review] [Project 1: Modernizing the P4 Software Switch BMv2](#project-1)
 - Category: exploratory P4 tooling
   - [Project 2: Realistic Traffic Manager and Queueing Architecture for P4 Switch Simulation in ns-3 (P4sim)](#project-2)
   - [Project 3: Polyglot P4TC: Python and Rust API Wrappers for Linux TC-based P4](#project-3)
@@ -81,7 +81,7 @@ It means we expect you to have made relevant contributions in order to demonstra
 
 **Note**
 
-The concrete contents of this project are under discussion at https://github.com/p4lang/gsoc/issues/87. Changes are expected.
+This project proposal is [under review](https://github.com/p4lang/gsoc/issues/87). Project description changes are expected.
 
 **Basic info**
 


### PR DESCRIPTION
Update: I put up a note to say that this project is under discussion instead.

~~@fruffy While addressing your concerns in https://github.com/p4lang/gsoc/issues/87, I think it's better to leave a less controversial version in the repo for now. This project description is directly copied from [last year](https://github.com/p4lang/gsoc/blob/main/2025/ideas_list.md#project-2).~~

~~@matthewtlam We shall update the project title & description later once we have some consensus in https://github.com/p4lang/gsoc/issues/87.~~