### PR TITLE
Fix typo in Project 2.3 mentor name

### DIFF
--- a/2026/ideas_list.md
+++ b/2026/ideas_list.md
@@ -578,7 +578,7 @@ You can explore all P4TC repos from the organization page here: [https://github.
 ![diffi-hard] ![size-l]
 
 - Potential mentors
-  - Primary: Takeoki Oura
+  - Primary: Takeaki Oura
   - Support: Ali Imran
 - Skills
   - Required: SystemVerilog (or Verilog) programming with Xilinx Vivado, Git


### PR DESCRIPTION
Sorry for the noise — I noticed a typo in my own name after the previous PR was merged(https://github.com/p4lang/gsoc/pull/76).

- Before: `Takeoki Oura`
- After:  `Takeaki Oura`