### PR TITLE
Build future-dated posts in all blog builds, drafts in previews

### DIFF
--- a/.github/workflows/blog-build.yml
+++ b/.github/workflows/blog-build.yml
@@ -49,13 +49,24 @@ jobs:
       # _meta/ before publishing, so it never reaches the live site. Written
       # inside the container because the build output may not be writable by
       # the host user.
+      #
+      # Future-dated posts are built everywhere (--buildFuture): post dates
+      # follow the report PR's merge time, so a future date is a placeholder
+      # awaiting correction, not a scheduling signal, and skipping it would
+      # hide a just-merged post until an unrelated push after that date.
+      # Drafts render only in PR previews so draft: true still means
+      # "not published" in production.
       - name: Build site
         uses: devcontainers/ci@v0.3
         with:
           runCmd: |
             set -e
-            hugo -s blog --minify --baseURL "${{ steps.cfg.outputs.base_url }}"
             pr="${{ github.event.pull_request.number }}"
+            extra_flags="--buildFuture"
+            if [ -n "$pr" ]; then
+              extra_flags="$extra_flags --buildDrafts"
+            fi
+            hugo -s blog --minify --baseURL "${{ steps.cfg.outputs.base_url }}" $extra_flags
             if [ -n "$pr" ]; then
               mkdir -p blog/public/_meta
               echo "$pr" > blog/public/_meta/pr_number.txt


### PR DESCRIPTION
## Motivation

In #116 the PR preview did not include the report post under review. Our convention sets post dates to the report PR's merge time, so while a PR is open its date is in the future, and Hugo skips future-dated content by default. The same default also affects production: a just-merged post can stay invisible on main until some unrelated push happens after its date passes, since deploys are push-triggered only.

Credit to @c8ef, whose [original analysis](https://github.com/p4lang/gsoc/pull/116#issuecomment-5203410073) correctly identified both the root cause and the shape of the fix:

> It might not be a bug, seems that hugo's default behavior is not rendering the blog post in the future. I think maybe we could render the draft/future in the pr preview, but in main branch deployment use the default option.
>
> ref: https://gohugo.io/getting-started/usage/#draft-future-and-expired-content

This PR follows that suggestion for drafts, and extends it slightly for future-dated posts: those are enabled in production too, for the reason below.

## Change

- Pass `--buildFuture` in all builds (production and previews). In this repo a future date is a placeholder awaiting the mergedAt fixup, never a scheduling signal, so the only effect of Hugo's default was hiding posts.
- Pass `--buildDrafts` only in PR preview builds, so contributors can preview `draft: true` posts while the flag still means unpublished in production.

## Impact

Report PR previews now render the post under review, and merged reports appear on the production blog immediately; the post-merge date fixup becomes a metadata correction only, no longer required for visibility. Open question: none known; if we ever want genuinely scheduled posts, `--buildFuture` on production would need revisiting.

## AI disclosure

This PR was prepared by Claude Code (model: Claude Fable 5), an AI agent operated by and under the direction of @qobilidop, following the [P4 AI tool use policy](https://github.com/p4lang/.github/blob/main/AIPOLICY.md). The diagnosis, recommendation, and this description were drafted by the agent; the maintainer reviewed the reasoning and approved the change and PR creation. The commit lists the agent as co-author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
