### PR TITLE
Fix aspect ratio of report images with fixed height attributes

### DIFF
--- a/blog/assets/css/extended/post-images.css
+++ b/blog/assets/css/extended/post-images.css
@@ -1,0 +1,9 @@
+/* Reports pasted from GitHub-rendered HTML carry fixed width/height
+   attributes on <img> tags. PaperMod caps images at max-width: 100% but
+   leaves the height pinned at the attribute value, distorting the aspect
+   ratio in the narrower content column. Restoring height: auto lets the
+   browser scale both dimensions together; the attributes still provide
+   the intrinsic aspect ratio before load, avoiding layout shift. */
+.post-content img {
+    height: auto;
+}


### PR DESCRIPTION
## Motivation

Images in the [SpliDT report](https://p4lang.github.io/gsoc/blog/posts/2025-09-09-splidt/) render with distorted aspect ratios. The post embeds screenshots as raw HTML pasted from GitHub attachments, which carry fixed `width`/`height` attributes. PaperMod caps images at `max-width: 100%` but never resets the height, so the `height` attribute pins the rendered height while the width shrinks to fit the ~720px content column, stretching the image vertically.

## Change

Add one rule in the blog's extended CSS: `.post-content img { height: auto; }`. With `height: auto` the browser scales both dimensions together, and the `width`/`height` attributes become purely beneficial: they give the browser the intrinsic aspect ratio before the image loads, preventing layout shift. This also future-proofs reports migrated the same way, so no post edits are needed.

## Before vs after

Measured in Chrome on the live site (before) and a local build of this branch (after), at the default 720px content width:

| Image | Intrinsic size (ratio) | Before: rendered (ratio) | After: rendered (ratio) |
|---|---|---|---|
| GSoC x P4 banner | 1400x604 (2.32) | 720x604 (1.19) | 720x311 (2.32) |
| Results screenshot | 1468x762 (1.93) | 720x381 (1.89) | 720x374 (1.93) |
| Architecture diagram | 2518x1268 (1.99) | 720x1268 (0.57) | 720x363 (1.98) |

The architecture diagram was the worst case, rendered about 3.5x taller than it should be. Screenshots of that diagram (durable record; the live page and PR preview links change once this merges):

**Before:**

<img width="1456" height="836" alt="splidt-diagram-before" src="https://github.com/user-attachments/assets/3b2e3557-d57a-41cc-8a11-2b3be1cc4973" />

**After:**

<img width="1456" height="836" alt="splidt-diagram-after" src="https://github.com/user-attachments/assets/901e6690-43a3-4f1b-9755-99e58ea75267" />

For live review while this PR is open: [production page (before)](https://p4lang.github.io/gsoc/blog/posts/2025-09-09-splidt/) vs [PR preview (after)](https://p4lang.github.io/gsoc/blog/pr-preview/pr-118/posts/2025-09-09-splidt/).

## AI disclosure

This PR was prepared by Claude Code (model: Claude Fable 5), an AI agent operated by and under the direction of @qobilidop, following the [P4 AI tool use policy](https://github.com/p4lang/.github/blob/main/AIPOLICY.md). The diagnosis, fix, browser-based verification, and this description were drafted by the agent; the maintainer reviewed the reasoning and approved the change and PR creation. The commit lists the agent as co-author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
