### PR TITLE
Blog improvements: navigation, search, post tools, and infra hardening

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git \
     && rm -rf /var/lib/apt/lists/*
 
-ARG GO_VERSION=1.26.4
-ARG HUGO_VERSION=0.163.3
+ARG GO_VERSION=1.26.5
+ARG HUGO_VERSION=0.164.0
 
 # Install Go.
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \

--- a/.github/workflows/blog-build.yml
+++ b/.github/workflows/blog-build.yml
@@ -56,6 +56,10 @@ jobs:
       # hide a just-merged post until an unrelated push after that date.
       # Drafts render only in PR previews so draft: true still means
       # "not published" in production.
+      #
+      # PR previews build in a non-production Hugo environment, which makes
+      # the theme emit noindex robots meta on every page, keeping preview
+      # copies out of search engines.
       - name: Build site
         uses: devcontainers/ci@v0.3
         with:
@@ -64,7 +68,7 @@ jobs:
             pr="${{ github.event.pull_request.number }}"
             extra_flags="--buildFuture"
             if [ -n "$pr" ]; then
-              extra_flags="$extra_flags --buildDrafts"
+              extra_flags="$extra_flags --buildDrafts --environment preview"
             fi
             hugo -s blog --minify --baseURL "${{ steps.cfg.outputs.base_url }}" $extra_flags
             if [ -n "$pr" ]; then

--- a/.github/workflows/blog-deploy.yml
+++ b/.github/workflows/blog-deploy.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Determine deploy target
         id: target
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/blog/content/archives.md
+++ b/blog/content/archives.md
@@ -1,0 +1,6 @@
+---
+title: "Archive"
+layout: "archives"
+url: "archives/"
+summary: "All reports grouped by year"
+---

--- a/blog/content/search.md
+++ b/blog/content/search.md
@@ -1,0 +1,7 @@
+---
+title: "Search"
+layout: "search"
+url: "search/"
+summary: "Search all reports"
+placeholder: "Search reports..."
+---

--- a/blog/go.mod
+++ b/blog/go.mod
@@ -2,4 +2,4 @@ module github.com/p4lang/gsoc/blog
 
 go 1.25
 
-require github.com/adityatelange/hugo-PaperMod v0.0.0-20260410194614-893811ac431f
+require github.com/adityatelange/hugo-PaperMod v0.0.0-20260802175912-d3768854d00a // indirect

--- a/blog/go.sum
+++ b/blog/go.sum
@@ -1,2 +1,2 @@
-github.com/adityatelange/hugo-PaperMod v0.0.0-20260410194614-893811ac431f h1:7hI1eNWE3Ng2lEYeLO00d7FficPn1Pf/7G6jAc7aS2E=
-github.com/adityatelange/hugo-PaperMod v0.0.0-20260410194614-893811ac431f/go.mod h1:HCHxNMKYdGafUYjVV3ICiAqznZK2yH0iI53jqcDFDdQ=
+github.com/adityatelange/hugo-PaperMod v0.0.0-20260802175912-d3768854d00a h1:Bkfmfl/zjay3M8OOMx7tALMHDYc9jRwj5rUKN4OzOPc=
+github.com/adityatelange/hugo-PaperMod v0.0.0-20260802175912-d3768854d00a/go.mod h1:sp5WH671pzcVNpWKveBQKlBfu6T9uvcBI/4B3BSojKw=

--- a/blog/hugo.toml
+++ b/blog/hugo.toml
@@ -10,6 +10,20 @@ copyright = "© [p4lang/gsoc contributors](https://github.com/p4lang/gsoc/graphs
 [pagination]
   pagerSize = 10
 
+# The JSON home output is the Fuse.js index PaperMod's search page consumes.
+[outputs]
+  home = ["html", "rss", "json"]
+
+[menus]
+  [[menus.main]]
+    name = "Archive"
+    url = "archives/"
+    weight = 10
+  [[menus.main]]
+    name = "Search"
+    url = "search/"
+    weight = 20
+
 # Project reports use raw HTML (<img>, <picture>, <br>), which Goldmark
 # strips by default.
 [markup.goldmark.renderer]

--- a/blog/hugo.toml
+++ b/blog/hugo.toml
@@ -38,6 +38,8 @@ copyright = "© [p4lang/gsoc contributors](https://github.com/p4lang/gsoc/graphs
   ShowToc = true
   ShowCodeCopyButtons = true
   ShowShareButtons = true
+  ShowPostNavLinks = true
+  ShowBreadCrumbs = true
 
   # Renders next to the post meta via the edit_post partial (shadowed in
   # layouts/_partials/ to also show the permapage link).

--- a/blog/hugo.toml
+++ b/blog/hugo.toml
@@ -36,3 +36,5 @@ copyright = "© [p4lang/gsoc contributors](https://github.com/p4lang/gsoc/graphs
   ShowReadingTime = true
   ShowWordCount = true
   ShowToc = true
+  ShowCodeCopyButtons = true
+  ShowShareButtons = true

--- a/blog/hugo.toml
+++ b/blog/hugo.toml
@@ -33,14 +33,14 @@ copyright = "© [p4lang/gsoc contributors](https://github.com/p4lang/gsoc/graphs
   # Keep all home-page post cards uniform (no hero for the newest post).
   disableSpecial1stPost = true
 
-  ShowReadingTime = true
-  ShowWordCount = true
-  ShowToc = true
-  ShowCodeCopyButtons = true
-  ShowShareButtons = true
   ShareButtons = ["x", "linkedin", "reddit", "ycombinator"]
-  ShowPostNavLinks = true
   ShowBreadCrumbs = true
+  ShowCodeCopyButtons = true
+  ShowPostNavLinks = true
+  ShowReadingTime = true
+  ShowShareButtons = true
+  ShowToc = true
+  ShowWordCount = true
 
   # Renders next to the post meta via the edit_post partial (shadowed in
   # layouts/_partials/ to also show the permapage link).

--- a/blog/hugo.toml
+++ b/blog/hugo.toml
@@ -38,3 +38,10 @@ copyright = "© [p4lang/gsoc contributors](https://github.com/p4lang/gsoc/graphs
   ShowToc = true
   ShowCodeCopyButtons = true
   ShowShareButtons = true
+
+  # Renders next to the post meta via the edit_post partial (shadowed in
+  # layouts/_partials/ to also show the permapage link).
+  [params.editPost]
+    URL = "https://github.com/p4lang/gsoc/blob/main/blog/content"
+    Text = "Suggest Changes"
+    appendFilePath = true

--- a/blog/hugo.toml
+++ b/blog/hugo.toml
@@ -38,6 +38,7 @@ copyright = "© [p4lang/gsoc contributors](https://github.com/p4lang/gsoc/graphs
   ShowToc = true
   ShowCodeCopyButtons = true
   ShowShareButtons = true
+  ShareButtons = ["x", "linkedin", "reddit", "ycombinator"]
   ShowPostNavLinks = true
   ShowBreadCrumbs = true
 

--- a/blog/layouts/_partials/edit_post.html
+++ b/blog/layouts/_partials/edit_post.html
@@ -4,26 +4,36 @@
        the same post-meta slot.
 
        Copied from the theme commit pinned in go.mod:
-       https://github.com/adityatelange/hugo-PaperMod/blob/893811ac431f/layouts/partials/edit_post.html
-       (the theme still used the legacy layouts/partials/ path at that
-       commit; Hugo resolves it and this file's layouts/_partials/ path to
-       the same template name). When bumping the theme module, re-diff the
-       upstream file and refresh the copy. */ -}}
-{{- if and (or .Params.editPost.URL site.Params.editPost.URL) (not (.Param "editPost.disabled")) -}}
-{{- $fileUrlPath := path.Join .File.Path }}
+       https://github.com/adityatelange/hugo-PaperMod/blob/d3768854d00a/layouts/_partials/edit_post.html
+       When bumping the theme module, re-diff the upstream file and refresh
+       the copy. */ -}}
+{{- if and (.Param "editPost.URL") (not (.Param "editPost.disabled")) -}}
+    {{- if or (.Param "author") (.Param "ShowReadingTime") (not .Date.IsZero) .IsTranslated }}
+        {{- printf "&nbsp;|&nbsp;" | safeHTML -}}
+    {{- end -}}
 
-{{- if or .Params.author site.Params.author (.Param "ShowReadingTime") (not .Date.IsZero) .IsTranslated }}&nbsp;|&nbsp;{{- end -}}
-<span>
-    <a href="{{ .Params.editPost.URL | default site.Params.editPost.URL }}{{ if .Params.editPost.appendFilePath | default ( site.Params.editPost.appendFilePath | default false ) }}/{{ $fileUrlPath }}{{ end }}" rel="noopener noreferrer edit" target="_blank">
-        {{- .Params.editPost.Text | default (site.Params.editPost.Text | default (i18n "edit_post" | default "Edit")) -}}
-    </a>
-</span>
+    {{- $editURL := .Param "editPost.URL" }}
+    {{- $appendFilePath := .Param "editPost.appendFilePath" | default false }}
+    {{- $editText := .Param "editPost.Text" | default (i18n "edit_post" ) -}}
+
+    {{- if $appendFilePath -}}
+        {{- $fileUrlPath := path.Join .File.Path }}
+        {{- $editURL = printf "%s/%s" $editURL $fileUrlPath -}}
+    {{- end -}}
+
+    <span>
+        <a href="{{ $editURL }}" rel="noopener noreferrer edit" target="_blank">
+            {{- $editText -}}
+        </a>
+    </span>
 {{- end }}
 {{- /* Site addition start: permapage link */ -}}
 {{- with .Param "permapage" -}}
-{{- if or $.Params.author site.Params.author ($.Param "ShowReadingTime") (not $.Date.IsZero) $.IsTranslated }}&nbsp;|&nbsp;{{- end -}}
-<span>
-    <a href="{{ . }}" rel="noopener noreferrer" target="_blank">Project permapage</a>
-</span>
+    {{- if or ($.Param "author") ($.Param "ShowReadingTime") (not $.Date.IsZero) $.IsTranslated }}
+        {{- printf "&nbsp;|&nbsp;" | safeHTML -}}
+    {{- end -}}
+    <span>
+        <a href="{{ . }}" rel="noopener noreferrer" target="_blank">Project permapage</a>
+    </span>
 {{- end }}
 {{- /* Site addition end */ -}}


### PR DESCRIPTION
## Motivation

A general blog improvements PR, in two parts: reader-facing features inspired by [Lil'Log](https://lilianweng.github.io/) (a popular blog on the same Hugo + PaperMod stack), and a fix from an infrastructure audit of our workflows and dev container.

## Reader-facing features

One commit per feature; all built into PaperMod:

- **Archive and Search pages, with a navigation menu.** The archive groups reports by program year. Search is client-side Fuse.js over a JSON index of all posts. The header menu (previously empty) links to both.
- **Code copy buttons** on fenced code blocks.
- **Share buttons** on posts, limited to a tech-audience subset (X, LinkedIn, Reddit, Hacker News).
- **Suggest Changes link** on each post, pointing to the post's source in this repo, rendered alongside the existing permapage link.
- **Breadcrumbs and prev/next post links.**

## Infrastructure fix from the audit

- **PR previews are excluded from search indexing.** Preview builds use a non-production Hugo environment, so every preview page gets noindex, nofollow robots meta; production keeps index, follow. This prevents preview copies from being indexed as duplicate content.

## Version bumps

- **PaperMod** from the 2026-04-10 pin to current master, with the `edit_post` shadow re-synced against the upstream refactor (keeping our permapage addition).
- **Hugo** 0.163.3 to 0.164.0 and **Go** 1.26.4 to 1.26.5 in the dev container.
- **actions/github-script** v8 to v9; the v9 breaking changes only affect scripts requiring `@actions/github` directly, which ours does not.

The theme's Hugo deprecation warnings persist upstream and are unaffected. Deferred deliberately: owning the Pages deploy step (only worth it if the 2026-08-06 deploy slowness persists) and CI container-image caching (needs org-level package setup).

## Verification

Built locally and exercised in a browser: searching "packet" returns the three packet-related reports; the archive renders 2025 and 2024 year groups; a post shows the meta line "... | Suggest Changes | Project permapage" with the correct GitHub source URL, the four share buttons, breadcrumbs, prev/next links, and a copy button per code block. Preview and production environments were both built locally to confirm the robots meta differs as intended. All features were re-verified after the version bumps on a force-rebuilt container running Hugo 0.164.0. Live preview: [home](https://p4lang.github.io/gsoc/blog/pr-preview/pr-119/), [archive](https://p4lang.github.io/gsoc/blog/pr-preview/pr-119/archives/), [search](https://p4lang.github.io/gsoc/blog/pr-preview/pr-119/search/).

## AI disclosure

This PR was prepared by Claude Code (model: Claude Fable 5), an AI agent operated by and under the direction of @qobilidop, following the [P4 AI tool use policy](https://github.com/p4lang/.github/blob/main/AIPOLICY.md). The maintainer selected the features, requested the audit, and approved the changes and PR; commits list the agent as co-author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
