### PR TITLE
Fix footer reference in 2026 SpecTec report

### DIFF
--- a/blog/content/posts/2026-08-12-p4-spectec/index.md
+++ b/blog/content/posts/2026-08-12-p4-spectec/index.md
@@ -252,4 +252,4 @@ one good candidate: it touches the IR definitions, type checking, and
 evaluation, requires the reader to think about where validity is checked and how
 it propagates.
 
-[^1]: [P4-SpecTec: A Mechanized Specification for P4 (Lee et al., 2026)](https://arxiv.org/abs/2608.00639)
+[^1]: [P4-SpecTec: Integrating a Language Mechanization Framework into the Real-World P4 Specification (Lee et al., 2026)](https://arxiv.org/abs/2608.00639)


### PR DESCRIPTION
I keep finding minor errors in my report; so here's another edit.
This PR corrects a misnamed paper title in the footer.